### PR TITLE
Enable log rotation of Django logs

### DIFF
--- a/temmpo/settings/base.py
+++ b/temmpo/settings/base.py
@@ -151,10 +151,11 @@ LOGGING = {
         },
         'local_file': {
             'level': 'INFO',
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
             'formatter': 'verbose',
             'filename': '%s/var/log/django.log' % PROJECT_ROOT,
-            'maxBytes': 1024 * 1024 * 10,
+            'when': 'D',
+            'backupCount': 60,
         },
         'mail_admins': {
             'level': 'ERROR',


### PR DESCRIPTION
This changes to a TimedRotatingFileHandler with approximately two months of logs kept, rotating daily.