### PR TITLE
Switch to WatchedFileHandler for logs

### DIFF
--- a/temmpo/settings/base.py
+++ b/temmpo/settings/base.py
@@ -151,11 +151,9 @@ LOGGING = {
         },
         'local_file': {
             'level': 'INFO',
-            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'class': 'logging.handlers.WatchedFileHandler',
             'formatter': 'verbose',
             'filename': '%s/var/log/django.log' % PROJECT_ROOT,
-            'when': 'D',
-            'backupCount': 60,
         },
         'mail_admins': {
             'level': 'ERROR',


### PR DESCRIPTION
Unfortunately, the TimedRotatingFileHandler didn't rotate successfully, potentially due to the multiprocess nature of this app runs. Instead of wrestling with socket listeners and similar, instead configure Django to re-open files when needed and managed the log rotation with an external tool (such as `logrotate`)